### PR TITLE
Sort the C files before processing them

### DIFF
--- a/clay.py
+++ b/clay.py
@@ -100,6 +100,7 @@ class ClayTestBuilder:
             module_root = [c for c in module_root.split(os.sep) if c]
 
             tests_in_module = fnmatch.filter(files, "*.c")
+            tests_in_module.sort()
 
             for test_file in tests_in_module:
                 full_path = os.path.join(root, test_file)


### PR DESCRIPTION
Otherwise they are parsed in random order and running clay on an
unchanged source tree produces changes in the generated files, and a
lot of noise is produced in the diff when adding tests.

Signed-off-by: Carlos Martín Nieto carlos@cmartin.tk
