### PR TITLE
Include <sys/wait.h>

### DIFF
--- a/clay.c
+++ b/clay.c
@@ -29,6 +29,7 @@
 #	define S_ISDIR(x) ((x & _S_IFDIR) != 0)
 	typedef struct _stat STAT_T;
 #else
+#	include <sys/wait.h> /* waitpid(2) */
 #	include <unistd.h>
 #	define _CC
 	typedef struct stat STAT_T;


### PR DESCRIPTION
This should be included to use waitpid(2). On OpenBSD, compilation
fails without it.

Signed-off-by: Carlos Martín Nieto carlos@cmartin.tk
