### PR TITLE
Report errors before aborting from cleanup exceptions

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -346,6 +346,7 @@ clar__assert(
 		if (!_clar.trampoline_enabled) {
 			clar_print_onabort(
 				"Fatal error: a cleanup method raised an exception.");
+			clar_report_errors();
 			exit(-1);
 		}
 


### PR DESCRIPTION
Might make debugging a bit easier next time
