### PR TITLE
clar_unsandbox: Always chdir up, on all platforms

### DIFF
--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -61,9 +61,7 @@ static void clar_unsandbox(void)
 	if (_clar_path[0] == '\0')
 		return;
 
-#ifdef _WIN32
 	chdir("..");
-#endif
 
 	fs_rm(_clar_path);
 }


### PR DESCRIPTION
This call to `chdir` seems generally useful. On Solaris, if you don't call it, you'll get an error at the end of test execution about being unable to rmdir a path that is along the path to the working directory. So maybe we should do it all the time. Unless you know of a reason not to?
