### PR TITLE
Convert snprint_eq to a variadic macro for MSVC

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -36,7 +36,7 @@
 #		define strncpy(to, from, to_size) strncpy_s(to, to_size, from, _TRUNCATE)
 #		define W_OK 02
 #		define S_ISDIR(x) ((x & _S_IFDIR) != 0)
-#		define snprint_eq(buf,sz,fmt,a,b) _snprintf_s(buf,sz,_TRUNCATE,fmt,a,b)
+#		define snprint_eq(buf,sz,fmt,...) _snprintf_s(buf,sz,_TRUNCATE,fmt,__VA_ARGS__)
 #	else
 #		define snprint_eq snprintf
 #	endif


### PR DESCRIPTION
This fixes a warning emitted by MSVC, because `snprint_eq` is being called with 6 arguments, and the macro expects 5. Variadic macros have been supported in MSVC [since Visual Studio 2005](http://msdn.microsoft.com/en-us/library/ms177415%28v=vs.80%29.aspx).

Discovered while working on https://github.com/libgit2/libgit2/pull/1767.
