### PR TITLE
Use struct stat on MSVC, get rid of warning

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -65,7 +65,12 @@
 #	ifndef PRIxZ
 #		define PRIxZ "Ix"
 #	endif
+
+#	ifdef _MSC_VER
+	typedef struct stat STAT_T;
+#	else
 	typedef struct _stat STAT_T;
+#	endif
 #else
 #	include <sys/wait.h> /* waitpid(2) */
 #	include <unistd.h>


### PR DESCRIPTION
There's only one warning when building libgit2 on MSVC (x86) and it's driving me crazy.
