### PR TITLE
generate.py specifies encoding for test files

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -118,7 +118,7 @@ class Module(object):
             self.modified = True
             self.mtime = st.st_mtime
 
-            with open(path) as fp:
+            with codecs.open(path, encoding='utf-8') as fp:
                 raw_content = fp.read()
 
         except IOError:


### PR DESCRIPTION
On many Windows systems, the default encoding is not utf-8. If there are test files containing non-ASCII characters that do not map properly to the default encoding, generate.py crashes.

Migrated from [libgit2#2247](https://github.com/libgit2/libgit2/pull/2247)
