### PR TITLE
Make -f option action="store_true" so that it does not consume the next argument.

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -230,7 +230,7 @@ if __name__ == '__main__':
     from optparse import OptionParser
 
     parser = OptionParser()
-    parser.add_option('-f', '--force', dest='force', default=False)
+    parser.add_option('-f', '--force', action="store_true", dest='force', default=False)
     parser.add_option('-x', '--exclude', dest='excluded', action='append', default=[])
 
     options, args = parser.parse_args()


### PR DESCRIPTION
As it was, if you passed the -f option the following option would be consumed and stored in options.force.  If you head to [this example branch](https://github.com/transcriptic/clar/tree/optparse-error-example) and run the same clar generate command used in [libgit2](https://github.com/libgit2/libgit2/blob/development/CMakeLists.txt#L424):

```
$ python generate.py -f -xonline -xstress .
```

You'll see that `options.f == "-xonline"` and that `options.excluded == ['stress']`.
