### PR TITLE
Allow test file paths with hyphens by replacing hyphens with underscores in module name

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -150,7 +150,7 @@ class TestSuite(object):
 
             for test_file in tests_in_module:
                 full_path = os.path.join(root, test_file)
-                module_name = "_".join(module_root + [test_file[:-2]])
+                module_name = "_".join(module_root + [test_file[:-2]]).replace("-", "_")
 
                 modules.append((full_path, module_name))
 


### PR DESCRIPTION
We like to have a `tests` dir that exactly mirrors the structure of our projects' `src` directory.  In the following example, `generate.py` scans the `tests` directory for tests:

```
/
  src/
    data-structures/
      circular-buffer.c
  tests/
    data-structures/
      circular-buffer.c
```

Because the filenames are used for the test names, leaving the the hyphen necessitates illegal test function names.  For example, the circular buffer initialize function would need to look like:

```
void test_data-structures_circular-buffer__initialize(void);
```

which is not valid C.  Substituting underscores for hyphens in module names fixes this.

This should not break any existing systems because before this, tests could not exist in files whose path viewed by `generate.py` contained a hyphen.

If this approach is too rigid for you, I can add an optional substitutes argument (or something similar) to the TestSuite constructor which species `tr` style substitutions that should take place in the module names.  That's a bit more involved than this one liner, though.
