### PR TITLE
sandbox: allow custom temp dirname

### DIFF
--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -72,7 +72,12 @@ static void clar_unsandbox(void)
 
 static int build_sandbox_path(void)
 {
+#ifdef CLAR_TMPDIR
+	const char path_tail[] = CLAR_TMPDIR "_XXXXXX";
+#else
 	const char path_tail[] = "clar_tmp_XXXXXX";
+#endif
+
 	size_t len;
 
 	if (find_tmp_path(_clar_path, sizeof(_clar_path)) < 0)


### PR DESCRIPTION
If one is a sane person and uses clar for all of their projects, then one may end up with a temp dir with several `clar_tmp_XXXXXX` folders and it may be difficult to determine which temp folders correspond to which projects.
