### PR TITLE
Correctly account for "duplicated" suites when counting

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -210,7 +210,7 @@ class TestSuite(object):
                     module.modified = True
 
     def suite_count(self):
-        return len(self.modules)
+        return sum(max(1, len(m.initializers)) for m in self.modules.values())
 
     def callback_count(self):
         return sum(len(module.callbacks) for module in self.modules.values())


### PR DESCRIPTION
Failing to do that makes clar miss the last of the suites, as all duplicated "data" would have not been accounted for.