### PR TITLE
TAP style output

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -96,6 +96,7 @@ fixture_path(const char *base, const char *fixture_name);
 
 struct clar_error {
 	const char *file;
+	const char *function;
 	size_t line_number;
 	const char *error_msg;
 	char *description;
@@ -603,6 +604,7 @@ void clar__skip(void)
 
 void clar__fail(
 	const char *file,
+	const char *function,
 	size_t line,
 	const char *error_msg,
 	const char *description,
@@ -619,6 +621,7 @@ void clar__fail(
 	_clar.last_report->last_error = error;
 
 	error->file = file;
+	error->function = function;
 	error->line_number = line;
 	error->error_msg = error_msg;
 
@@ -635,6 +638,7 @@ void clar__fail(
 void clar__assert(
 	int condition,
 	const char *file,
+	const char *function,
 	size_t line,
 	const char *error_msg,
 	const char *description,
@@ -643,11 +647,12 @@ void clar__assert(
 	if (condition)
 		return;
 
-	clar__fail(file, line, error_msg, description, should_abort);
+	clar__fail(file, function, line, error_msg, description, should_abort);
 }
 
 void clar__assert_equal(
 	const char *file,
+	const char *function,
 	size_t line,
 	const char *err,
 	int should_abort,
@@ -758,7 +763,7 @@ void clar__assert_equal(
 	va_end(args);
 
 	if (!is_equal)
-		clar__fail(file, line, err, buf, should_abort);
+		clar__fail(file, function, line, err, buf, should_abort);
 }
 
 void cl_set_cleanup(void (*cleanup)(void *), void *opaque)

--- a/clar.c
+++ b/clar.c
@@ -363,6 +363,7 @@ clar_usage(const char *arg)
 	printf("  -v            Increase verbosity (show suite names)\n");
 	printf("  -q            Only report tests that had an error\n");
 	printf("  -Q            Quit as soon as a test fails\n");
+	printf("  -t            Display results in tap format\n");
 	printf("  -l            Print suite names\n");
 	printf("  -r[filename]  Write summary file (to the optional filename)\n");
 	exit(-1);
@@ -378,7 +379,7 @@ clar_parse_args(int argc, char **argv)
 		char *argument = argv[i];
 
 		if (argument[0] != '-' || argument[1] == '\0'
-		    || strchr("sixvqQlr", argument[1]) == NULL) {
+		    || strchr("sixvqQtlr", argument[1]) == NULL) {
 			clar_usage(argv[0]);
 		}
 	}
@@ -459,6 +460,10 @@ clar_parse_args(int argc, char **argv)
 
 		case 'Q':
 			_clar.exit_on_error = 1;
+			break;
+
+		case 't':
+			_clar.output_format = CL_OUTPUT_TAP;
 			break;
 
 		case 'l': {

--- a/clar.c
+++ b/clar.c
@@ -487,6 +487,9 @@ clar_parse_args(int argc, char **argv)
 void
 clar_test_init(int argc, char **argv)
 {
+	if (argc > 1)
+		clar_parse_args(argc, argv);
+
 	clar_print_init(
 		(int)_clar_callback_count,
 		(int)_clar_suite_count,
@@ -497,9 +500,6 @@ clar_test_init(int argc, char **argv)
 		_clar.write_summary = 1;
 		_clar.summary_filename = strdup(_clar.summary_filename);
 	}
-
-	if (argc > 1)
-		clar_parse_args(argc, argv);
 
 	if (_clar.write_summary &&
 	    !(_clar.summary = clar_summary_init(_clar.summary_filename))) {

--- a/clar.c
+++ b/clar.c
@@ -140,6 +140,8 @@ static struct {
 	int tests_ran;
 	int suites_ran;
 
+	enum cl_output_format output_format;
+
 	int report_errors_only;
 	int exit_on_error;
 	int report_suite_names;

--- a/clar.h
+++ b/clar.h
@@ -16,6 +16,10 @@ enum cl_test_status {
 	CL_TEST_NOTRUN,
 };
 
+enum cl_output_format {
+	CL_OUTPUT_CLAP,
+};
+
 /** Setup clar environment */
 void clar_test_init(int argc, char *argv[]);
 int clar_test_run(void);

--- a/clar.h
+++ b/clar.h
@@ -86,16 +86,16 @@ const char *cl_fixture_basename(const char *fixture_name);
 /**
  * Assertion macros with explicit error message
  */
-#define cl_must_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __LINE__, "Function call failed: " #expr, desc, 1)
-#define cl_must_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __LINE__, "Expected function call to fail: " #expr, desc, 1)
-#define cl_assert_(expr, desc) clar__assert((expr) != 0, __FILE__, __LINE__, "Expression is not true: " #expr, desc, 1)
+#define cl_must_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __func__, __LINE__, "Function call failed: " #expr, desc, 1)
+#define cl_must_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __func__, __LINE__, "Expected function call to fail: " #expr, desc, 1)
+#define cl_assert_(expr, desc) clar__assert((expr) != 0, __FILE__, __func__, __LINE__, "Expression is not true: " #expr, desc, 1)
 
 /**
  * Check macros with explicit error message
  */
-#define cl_check_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __LINE__, "Function call failed: " #expr, desc, 0)
-#define cl_check_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __LINE__, "Expected function call to fail: " #expr, desc, 0)
-#define cl_check_(expr, desc) clar__assert((expr) != 0, __FILE__, __LINE__, "Expression is not true: " #expr, desc, 0)
+#define cl_check_pass_(expr, desc) clar__assert((expr) >= 0, __FILE__, __func__, __LINE__, "Function call failed: " #expr, desc, 0)
+#define cl_check_fail_(expr, desc) clar__assert((expr) < 0, __FILE__, __func__, __LINE__, "Expected function call to fail: " #expr, desc, 0)
+#define cl_check_(expr, desc) clar__assert((expr) != 0, __FILE__, __func__, __LINE__, "Expression is not true: " #expr, desc, 0)
 
 /**
  * Assertion macros with no error message
@@ -114,38 +114,39 @@ const char *cl_fixture_basename(const char *fixture_name);
 /**
  * Forced failure/warning
  */
-#define cl_fail(desc) clar__fail(__FILE__, __LINE__, "Test failed.", desc, 1)
-#define cl_warning(desc) clar__fail(__FILE__, __LINE__, "Warning during test execution:", desc, 0)
+#define cl_fail(desc) clar__fail(__FILE__, __func__, __LINE__, "Test failed.", desc, 1)
+#define cl_warning(desc) clar__fail(__FILE__, __func__, __LINE__, "Warning during test execution:", desc, 0)
 
 #define cl_skip() clar__skip()
 
 /**
  * Typed assertion macros
  */
-#define cl_assert_equal_s(s1,s2) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #s1 " != " #s2, 1, "%s", (s1), (s2))
-#define cl_assert_equal_s_(s1,s2,note) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #s1 " != " #s2 " (" #note ")", 1, "%s", (s1), (s2))
+#define cl_assert_equal_s(s1,s2) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #s1 " != " #s2, 1, "%s", (s1), (s2))
+#define cl_assert_equal_s_(s1,s2,note) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #s1 " != " #s2 " (" #note ")", 1, "%s", (s1), (s2))
 
-#define cl_assert_equal_wcs(wcs1,wcs2) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2, 1, "%ls", (wcs1), (wcs2))
-#define cl_assert_equal_wcs_(wcs1,wcs2,note) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2 " (" #note ")", 1, "%ls", (wcs1), (wcs2))
+#define cl_assert_equal_wcs(wcs1,wcs2) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2, 1, "%ls", (wcs1), (wcs2))
+#define cl_assert_equal_wcs_(wcs1,wcs2,note) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2 " (" #note ")", 1, "%ls", (wcs1), (wcs2))
 
-#define cl_assert_equal_strn(s1,s2,len) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #s1 " != " #s2, 1, "%.*s", (s1), (s2), (int)(len))
-#define cl_assert_equal_strn_(s1,s2,len,note) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #s1 " != " #s2 " (" #note ")", 1, "%.*s", (s1), (s2), (int)(len))
+#define cl_assert_equal_strn(s1,s2,len) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #s1 " != " #s2, 1, "%.*s", (s1), (s2), (int)(len))
+#define cl_assert_equal_strn_(s1,s2,len,note) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #s1 " != " #s2 " (" #note ")", 1, "%.*s", (s1), (s2), (int)(len))
 
-#define cl_assert_equal_wcsn(wcs1,wcs2,len) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2, 1, "%.*ls", (wcs1), (wcs2), (int)(len))
-#define cl_assert_equal_wcsn_(wcs1,wcs2,len,note) clar__assert_equal(__FILE__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2 " (" #note ")", 1, "%.*ls", (wcs1), (wcs2), (int)(len))
+#define cl_assert_equal_wcsn(wcs1,wcs2,len) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2, 1, "%.*ls", (wcs1), (wcs2), (int)(len))
+#define cl_assert_equal_wcsn_(wcs1,wcs2,len,note) clar__assert_equal(__FILE__,__func__,__LINE__,"String mismatch: " #wcs1 " != " #wcs2 " (" #note ")", 1, "%.*ls", (wcs1), (wcs2), (int)(len))
 
-#define cl_assert_equal_i(i1,i2) clar__assert_equal(__FILE__,__LINE__,#i1 " != " #i2, 1, "%d", (int)(i1), (int)(i2))
-#define cl_assert_equal_i_(i1,i2,note) clar__assert_equal(__FILE__,__LINE__,#i1 " != " #i2 " (" #note ")", 1, "%d", (i1), (i2))
-#define cl_assert_equal_i_fmt(i1,i2,fmt) clar__assert_equal(__FILE__,__LINE__,#i1 " != " #i2, 1, (fmt), (int)(i1), (int)(i2))
+#define cl_assert_equal_i(i1,i2) clar__assert_equal(__FILE__,__func__,__LINE__,#i1 " != " #i2, 1, "%d", (int)(i1), (int)(i2))
+#define cl_assert_equal_i_(i1,i2,note) clar__assert_equal(__FILE__,__func__,__LINE__,#i1 " != " #i2 " (" #note ")", 1, "%d", (i1), (i2))
+#define cl_assert_equal_i_fmt(i1,i2,fmt) clar__assert_equal(__FILE__,__func__,__LINE__,#i1 " != " #i2, 1, (fmt), (int)(i1), (int)(i2))
 
-#define cl_assert_equal_b(b1,b2) clar__assert_equal(__FILE__,__LINE__,#b1 " != " #b2, 1, "%d", (int)((b1) != 0),(int)((b2) != 0))
+#define cl_assert_equal_b(b1,b2) clar__assert_equal(__FILE__,__func__,__LINE__,#b1 " != " #b2, 1, "%d", (int)((b1) != 0),(int)((b2) != 0))
 
-#define cl_assert_equal_p(p1,p2) clar__assert_equal(__FILE__,__LINE__,"Pointer mismatch: " #p1 " != " #p2, 1, "%p", (p1), (p2))
+#define cl_assert_equal_p(p1,p2) clar__assert_equal(__FILE__,__func__,__LINE__,"Pointer mismatch: " #p1 " != " #p2, 1, "%p", (p1), (p2))
 
 void clar__skip(void);
 
 void clar__fail(
 	const char *file,
+	const char *func,
 	size_t line,
 	const char *error,
 	const char *description,
@@ -154,6 +155,7 @@ void clar__fail(
 void clar__assert(
 	int condition,
 	const char *file,
+	const char *func,
 	size_t line,
 	const char *error,
 	const char *description,
@@ -161,6 +163,7 @@ void clar__assert(
 
 void clar__assert_equal(
 	const char *file,
+	const char *func,
 	size_t line,
 	const char *err,
 	int should_abort,

--- a/clar.h
+++ b/clar.h
@@ -18,6 +18,7 @@ enum cl_test_status {
 
 enum cl_output_format {
 	CL_OUTPUT_CLAP,
+	CL_OUTPUT_TAP,
 };
 
 /** Setup clar environment */

--- a/clar/print.h
+++ b/clar/print.h
@@ -1,12 +1,12 @@
 
-static void clar_print_init(int test_count, int suite_count, const char *suite_names)
+static void clar_print_cl_init(int test_count, int suite_count, const char *suite_names)
 {
 	(void)test_count;
 	printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
 	printf("Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')\n");
 }
 
-static void clar_print_shutdown(int test_count, int suite_count, int error_count)
+static void clar_print_cl_shutdown(int test_count, int suite_count, int error_count)
 {
 	(void)test_count;
 	(void)suite_count;
@@ -16,7 +16,7 @@ static void clar_print_shutdown(int test_count, int suite_count, int error_count
 	clar_report_all();
 }
 
-static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error)
+static void clar_print_cl_error(int num, const struct clar_report *report, const struct clar_error *error)
 {
 	printf("  %d) Failure:\n", num);
 
@@ -35,7 +35,7 @@ static void clar_print_error(int num, const struct clar_report *report, const st
 	fflush(stdout);
 }
 
-static void clar_print_ontest(const char *test_name, int test_number, enum cl_test_status status)
+static void clar_print_cl_ontest(const char *test_name, int test_number, enum cl_test_status status)
 {
 	(void)test_name;
 	(void)test_number;
@@ -50,7 +50,7 @@ static void clar_print_ontest(const char *test_name, int test_number, enum cl_te
 	fflush(stdout);
 }
 
-static void clar_print_onsuite(const char *suite_name, int suite_index)
+static void clar_print_cl_onsuite(const char *suite_name, int suite_index)
 {
 	if (_clar.report_suite_names)
 		printf("\n%s", suite_name);
@@ -58,10 +58,40 @@ static void clar_print_onsuite(const char *suite_name, int suite_index)
 	(void)suite_index;
 }
 
+static void clar_print_cl_onabort(const char *fmt, va_list arg)
+{
+	vfprintf(stderr, fmt, arg);
+}
+
+static void clar_print_init(int test_count, int suite_count, const char *suite_names)
+{
+	clar_print_cl_init(test_count, suite_count, suite_names);
+}
+
+static void clar_print_shutdown(int test_count, int suite_count, int error_count)
+{
+	clar_print_cl_shutdown(test_count, suite_count, error_count);
+}
+
+static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error)
+{
+	clar_print_cl_error(num, report, error);
+}
+
+static void clar_print_ontest(const char *test_name, int test_number, enum cl_test_status status)
+{
+	clar_print_cl_ontest(test_name, test_number, status);
+}
+
+static void clar_print_onsuite(const char *suite_name, int suite_index)
+{
+	clar_print_cl_onsuite(suite_name, suite_index);
+}
+
 static void clar_print_onabort(const char *msg, ...)
 {
 	va_list argp;
 	va_start(argp, msg);
-	vfprintf(stderr, msg, argp);
+	clar_print_cl_onabort(msg, argp);
 	va_end(argp);
 }

--- a/clar/print.h
+++ b/clar/print.h
@@ -126,7 +126,7 @@ static void clar_print_tap_ontest(const char *test_name, int test_number, enum c
 		printf("    at:\n");
 		printf("      file: '"); print_escaped(error->file); printf("'\n");
 		printf("      line: %" PRIuZ "\n", error->line_number);
-		printf("      function: '%s::%s'\n", _clar.active_suite, test_name);
+		printf("      function: '%s'\n", error->function);
 		printf("    ---\n");
 
 		break;

--- a/clar/print.h
+++ b/clar/print.h
@@ -1,12 +1,13 @@
+/* clap: clar protocol, the traditional clar output format */
 
-static void clar_print_cl_init(int test_count, int suite_count, const char *suite_names)
+static void clar_print_clap_init(int test_count, int suite_count, const char *suite_names)
 {
 	(void)test_count;
 	printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
 	printf("Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')\n");
 }
 
-static void clar_print_cl_shutdown(int test_count, int suite_count, int error_count)
+static void clar_print_clap_shutdown(int test_count, int suite_count, int error_count)
 {
 	(void)test_count;
 	(void)suite_count;
@@ -16,7 +17,7 @@ static void clar_print_cl_shutdown(int test_count, int suite_count, int error_co
 	clar_report_all();
 }
 
-static void clar_print_cl_error(int num, const struct clar_report *report, const struct clar_error *error)
+static void clar_print_clap_error(int num, const struct clar_report *report, const struct clar_error *error)
 {
 	printf("  %d) Failure:\n", num);
 
@@ -35,7 +36,7 @@ static void clar_print_cl_error(int num, const struct clar_report *report, const
 	fflush(stdout);
 }
 
-static void clar_print_cl_ontest(const char *test_name, int test_number, enum cl_test_status status)
+static void clar_print_clap_ontest(const char *test_name, int test_number, enum cl_test_status status)
 {
 	(void)test_name;
 	(void)test_number;
@@ -50,7 +51,7 @@ static void clar_print_cl_ontest(const char *test_name, int test_number, enum cl
 	fflush(stdout);
 }
 
-static void clar_print_cl_onsuite(const char *suite_name, int suite_index)
+static void clar_print_clap_onsuite(const char *suite_name, int suite_index)
 {
 	if (_clar.report_suite_names)
 		printf("\n%s", suite_name);
@@ -58,40 +59,52 @@ static void clar_print_cl_onsuite(const char *suite_name, int suite_index)
 	(void)suite_index;
 }
 
-static void clar_print_cl_onabort(const char *fmt, va_list arg)
+static void clar_print_clap_onabort(const char *fmt, va_list arg)
 {
 	vfprintf(stderr, fmt, arg);
 }
 
+/* indirection between protocol output selection */
+
+#define PRINT(FN, args...) do { \
+		switch (_clar.output_format) { \
+			case CL_OUTPUT_CLAP: \
+				clar_print_clap_##FN (args); \
+				break; \
+			default: \
+				abort(); \
+		} \
+	} while (0)
+
 static void clar_print_init(int test_count, int suite_count, const char *suite_names)
 {
-	clar_print_cl_init(test_count, suite_count, suite_names);
+	PRINT(init, test_count, suite_count, suite_names);
 }
 
 static void clar_print_shutdown(int test_count, int suite_count, int error_count)
 {
-	clar_print_cl_shutdown(test_count, suite_count, error_count);
+	PRINT(shutdown, test_count, suite_count, error_count);
 }
 
 static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error)
 {
-	clar_print_cl_error(num, report, error);
+	PRINT(error, num, report, error);
 }
 
 static void clar_print_ontest(const char *test_name, int test_number, enum cl_test_status status)
 {
-	clar_print_cl_ontest(test_name, test_number, status);
+	PRINT(ontest, test_name, test_number, status);
 }
 
 static void clar_print_onsuite(const char *suite_name, int suite_index)
 {
-	clar_print_cl_onsuite(suite_name, suite_index);
+	PRINT(onsuite, suite_name, suite_index);
 }
 
 static void clar_print_onabort(const char *msg, ...)
 {
 	va_list argp;
 	va_start(argp, msg);
-	clar_print_cl_onabort(msg, argp);
+	PRINT(onabort, msg, argp);
 	va_end(argp);
 }

--- a/clar/print.h
+++ b/clar/print.h
@@ -64,12 +64,102 @@ static void clar_print_clap_onabort(const char *fmt, va_list arg)
 	vfprintf(stderr, fmt, arg);
 }
 
+/* tap: test anywhere protocol format */
+
+static void clar_print_tap_init(int test_count, int suite_count, const char *suite_names)
+{
+	(void)test_count;
+	(void)suite_count;
+	(void)suite_names;
+	printf("TAP version 13\n");
+}
+
+static void clar_print_tap_shutdown(int test_count, int suite_count, int error_count)
+{
+	(void)suite_count;
+	(void)error_count;
+
+	printf("1..%d\n", test_count);
+}
+
+static void clar_print_tap_error(int num, const struct clar_report *report, const struct clar_error *error)
+{
+	(void)num;
+	(void)report;
+	(void)error;
+}
+
+static void print_escaped(const char *str)
+{
+	char *c;
+
+	while ((c = strchr(str, '\'')) != NULL) {
+		printf("%.*s", (int)(c - str), str);
+		printf("''");
+		str = c + 1;
+	}
+
+	printf("%s", str);
+}
+
+static void clar_print_tap_ontest(const char *test_name, int test_number, enum cl_test_status status)
+{
+	const struct clar_error *error = _clar.last_report->errors;
+
+	(void)test_name;
+	(void)test_number;
+
+	switch(status) {
+	case CL_TEST_OK:
+		printf("ok %d - %s::%s\n", test_number, _clar.active_suite, test_name);
+		break;
+	case CL_TEST_FAILURE:
+		printf("not ok %d - %s::%s\n", test_number, _clar.active_suite, test_name);
+
+		printf("    ---\n");
+		printf("    reason: |\n");
+		printf("      %s\n", error->error_msg);
+
+		if (error->description)
+			printf("      %s\n", error->description);
+
+		printf("    at:\n");
+		printf("      file: '"); print_escaped(error->file); printf("'\n");
+		printf("      line: %" PRIuZ "\n", error->line_number);
+		printf("      function: '%s::%s'\n", _clar.active_suite, test_name);
+		printf("    ---\n");
+
+		break;
+	case CL_TEST_SKIP:
+	case CL_TEST_NOTRUN:
+		printf("ok %d - # SKIP %s::%s\n", test_number, _clar.active_suite, test_name);
+		break;
+	}
+
+	fflush(stdout);
+}
+
+static void clar_print_tap_onsuite(const char *suite_name, int suite_index)
+{
+	printf("# start of suite %d: %s\n", suite_index, suite_name);
+}
+
+static void clar_print_tap_onabort(const char *fmt, va_list arg)
+{
+	printf("Bail out! ");
+	vprintf(fmt, arg);
+	fflush(stdout);
+}
+
 /* indirection between protocol output selection */
 
-#define PRINT(FN, args...) do { \
+#define PRINT(FN, ...) do { \
 		switch (_clar.output_format) { \
 			case CL_OUTPUT_CLAP: \
-				clar_print_clap_##FN (args); \
+				clar_print_clap_##FN (__VA_ARGS__); \
+				break; \
+			case CL_OUTPUT_TAP: \
+				clar_print_tap_##FN (__VA_ARGS__); \
 				break; \
 			default: \
 				abort(); \


### PR DESCRIPTION
This adds a new command-line option to clar, `-t`, which will produce output in the popular TAP format, which can be used by multiple different frontends to display test output.

This retroactively names the existing clar output format as "clap" (the "clar protocol"), and adds support for tap (the [test anywhere protocol](https://testanything.org/)).

This adds support for [TAP version 13](https://testanything.org/tap-version-13-specification.html).

It includes the optional YAML block to provide more information about test failures.  Since this is not yet standardized, we have copied the output format of the popular [node tap](https://node-tap.org/tap-protocol).

Fixes #38