### PR TITLE
Only compile fixture functions when functions exist

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -94,8 +94,10 @@
 static void fs_rm(const char *_source);
 static void fs_copy(const char *_source, const char *dest);
 
+#ifdef CLAR_FIXTURE_PATH
 static const char *
 fixture_path(const char *base, const char *fixture_name);
+#endif
 
 struct clar_error {
 	const char *file;

--- a/clar/fixtures.h
+++ b/clar/fixtures.h
@@ -1,3 +1,4 @@
+#ifdef CLAR_FIXTURE_PATH
 static const char *
 fixture_path(const char *base, const char *fixture_name)
 {
@@ -20,7 +21,6 @@ fixture_path(const char *base, const char *fixture_name)
 	return _path;
 }
 
-#ifdef CLAR_FIXTURE_PATH
 const char *cl_fixture(const char *fixture_name)
 {
 	return fixture_path(CLAR_FIXTURE_PATH, fixture_name);

--- a/clar/fs.h
+++ b/clar/fs.h
@@ -295,7 +295,9 @@ fs_copy(const char *_source, const char *_dest)
 void
 cl_fs_cleanup(void)
 {
+#ifdef CLAR_FIXTURE_PATH
 	fs_rm(fixture_path(_clar_path, "*"));
+#endif
 }
 
 #else


### PR DESCRIPTION
Avoid unused function warnings for users who do not have fixtures.