### PR TITLE
Add support for builds on HPE NonStop.

### DIFF
--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -122,6 +122,12 @@ static int build_sandbox_path(void)
 
 	if (mkdir(_clar_path, 0700) != 0)
 		return -1;
+#elif defined(__TANDEM)
+	if (mktemp(_clar_path) == NULL)
+		return -1;
+
+	if (mkdir(_clar_path, 0700) != 0)
+		return -1;
 #elif defined(_WIN32)
 	if (_mktemp_s(_clar_path, sizeof(_clar_path)) != 0)
 		return -1;

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,7 +16,7 @@ TEST_DIRECTORY    := $(abspath $(dir $(CURRENT_MAKEFILE)))
 CLAR_PATH         := $(dir $(TEST_DIRECTORY))
 CLAR_FIXTURE_PATH := $(TEST_DIRECTORY)/resources/
 
-CFLAGS=-g -I.. -I. -Wall -DCLAR_FIXTURE_PATH=\"$(CLAR_FIXTURE_PATH)\"
+CFLAGS?=-g -I.. -I. -Wall -DCLAR_FIXTURE_PATH=\"$(CLAR_FIXTURE_PATH)\"
 
 .PHONY: clean
 


### PR DESCRIPTION
This change includes modifying Makefile so that CFLAGS can be overridden by an invoking Makefile or shell. It also modifies sandbox.h to support an older form of mktemp/mkdir supported on the NonStop platform.

Fixes: #95