### PR TITLE
global: fix whitespace errors

### DIFF
--- a/clar/fs.h
+++ b/clar/fs.h
@@ -146,7 +146,7 @@ fs_rm_wait(WCHAR *_wpath)
 			ERROR_PATH_NOT_FOUND == last_error)
 			return 0;
 
-		Sleep(RM_RETRY_DELAY * retries * retries);	
+		Sleep(RM_RETRY_DELAY * retries * retries);
 	}
 	while (retries++ <= RM_RETRY_COUNT);
 

--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -25,9 +25,9 @@ find_tmp_path(char *buffer, size_t length)
 	static const size_t var_count = 5;
 	static const char *env_vars[] = {
 		"CLAR_TMP", "TMPDIR", "TMP", "TEMP", "USERPROFILE"
- 	};
+	};
 
- 	size_t i;
+	size_t i;
 
 	for (i = 0; i < var_count; ++i) {
 		const char *env = getenv(env_vars[i]);
@@ -151,4 +151,3 @@ const char *clar_sandbox_path(void)
 {
 	return _clar_path;
 }
-

--- a/generate.py
+++ b/generate.py
@@ -264,4 +264,3 @@ if __name__ == '__main__':
     suite.disable(options.excluded)
     if suite.write():
         print("Written `clar.suite` (%d tests in %d suites)" % (suite.callback_count(), suite.suite_count()))
-

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -2,4 +2,3 @@ clar.suite
 .clarcache
 clar_test
 *.o
-


### PR DESCRIPTION
There are multiple places with broken whitespace formatting as pointed out by git-apply(1). Fix these to make the command happy.