### PR TITLE
Platform compatibility with MinGW and HPE NonStop

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -68,7 +68,7 @@
 #		define PRIxZ "Ix"
 #	endif
 
-#	if defined(_MSC_VER) || defined(__MINGW32__)
+#	if defined(_MSC_VER) || (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
 	typedef struct stat STAT_T;
 #	else
 	typedef struct _stat STAT_T;

--- a/clar.c
+++ b/clar.c
@@ -19,9 +19,9 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
+#	define WIN32_LEAN_AND_MEAN
 #	include <windows.h>
 #	include <io.h>
-#	include <shellapi.h>
 #	include <direct.h>
 
 #	define _MAIN_CC __cdecl

--- a/clar/fs.h
+++ b/clar/fs.h
@@ -297,6 +297,8 @@ cl_fs_cleanup(void)
 {
 #ifdef CLAR_FIXTURE_PATH
 	fs_rm(fixture_path(_clar_path, "*"));
+#else
+	((void)fs_copy); /* unused */
 #endif
 }
 

--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -128,6 +128,12 @@ static int build_sandbox_path(void)
 
 	if (mkdir(_clar_path, 0700) != 0)
 		return -1;
+#elif defined(__TANDEM)
+	if (mktemp(_clar_path) == NULL)
+		return -1;
+
+	if (mkdir(_clar_path, 0700) != 0)
+		return -1;
 #else
 	if (mkdtemp(_clar_path) == NULL)
 		return -1;


### PR DESCRIPTION
Fix a couple of platform compatibility issues with MinGW and HPE NonStop. These patches are required by Git to make the clar work for all currently tested platforms.

The HPE NonStop changes have been picked from https://github.com/clar-test/clar/pull/96, removing the other changes to make the CFLAGS overridable. The Windows fixes have been picked from the [downstream patch series in Git](https://lore.kernel.org/git/cover.1722415748.git.ps@pks.im/T/#meee619275b1c92f7966e65ce29969817e539e171).

The patches were originally by @rsbeckerca and @dscho. I have noted authorship via `Original-patch-by` trailers, but am happy to attribute full authorship of the commits if preferred by the authors.