### PR TITLE
clar: simplify how we handle stat(3P) on Win32

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -30,6 +30,9 @@
 
 #	ifndef stat
 #		define stat(path, st) _stat(path, st)
+		typedef struct _stat STAT_T;
+#	else
+		typedef struct stat STAT_T;
 #	endif
 #	ifndef mkdir
 #		define mkdir(path, mode) _mkdir(path)
@@ -61,12 +64,6 @@
 #		define p_snprintf(buf,sz,fmt,...) _snprintf_s(buf,sz,_TRUNCATE,fmt,__VA_ARGS__)
 #	else
 #		define p_snprintf snprintf
-#	endif
-
-#	if defined(_MSC_VER) || (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
-	typedef struct stat STAT_T;
-#	else
-	typedef struct _stat STAT_T;
 #	endif
 #else
 #	include <sys/wait.h> /* waitpid(2) */


### PR DESCRIPTION
The Windows platform has multiple different definitions for stat(3P) and its `struct stat` with different integer widths for both the filesize and the timestamps. For our usecase, we really only need to care whether we end up using `_stat()` or `stat()`, which require us to use either `struct _stat` or `struct stat`, respectively.

The way we handle this in "clar.c" is somewhat convoluted though because we select the function and structure to use independently of each other. This can cause us to pick the wrong combination of features in some environments, like mingw-w64.

Simplify the code such both function and struct get set up under the same condition such that this cannot happen anymore.