### PR TITLE
clar: define feature macros in "clar.c"

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -5,6 +5,9 @@
  * For full terms see the included COPYING file.
  */
 
+#define _DARWIN_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
 #include <errno.h>
 #include <setjmp.h>
 #include <stdlib.h>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,8 +28,6 @@ target_sources(clar_test PRIVATE
 )
 target_compile_definitions(clar_test PRIVATE
 	CLAR_FIXTURE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/resources/"
-	_DARWIN_C_SOURCE
-	_POSIX_C_SOURCE=200809L
 )
 target_compile_options(clar_test PRIVATE
 	$<IF:$<CXX_COMPILER_ID:MSVC>,/W4,-Wall>


### PR DESCRIPTION
Compiling clar requires several different extensions which are not part
of ISO C90, like strdup(3P), lstat(3P) and mkdtemp(3P). And while we
define these via our CMake build instructions, downstream users do not
benefit from this and will have to make sure that they set these.

Let's instead pull the definitions into "clar.c" such that the macros
are defined for everyone.