### PR TITLE
SunOS compatibility

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -5,8 +5,9 @@
  * For full terms see the included COPYING file.
  */
 
+#define _BSD_SOURCE
 #define _DARWIN_C_SOURCE
-#define _POSIX_C_SOURCE 200809L
+#define _DEFAULT_SOURCE
 
 #include <errno.h>
 #include <setjmp.h>

--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -128,7 +128,7 @@ static int build_sandbox_path(void)
 
 	if (mkdir(_clar_path, 0700) != 0)
 		return -1;
-#elif defined(__TANDEM)
+#elif defined(__sun) || defined(__TANDEM)
 	if (mktemp(_clar_path) == NULL)
 		return -1;
 


### PR DESCRIPTION
The clar does not compile on SunOS because it does not support POSIX.1-2008. This PR makes things work on that platform.