### PR TITLE
Use random sandbox names (by default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,15 @@
+include(CheckFunctionExists)
+
 cmake_minimum_required(VERSION 3.16..3.29)
 
 project(clar LANGUAGES C)
 
 option(BUILD_EXAMPLE "Build the example." ON)
+
+check_function_exists(realpath CLAR_HAS_REALPATH)
+if(CLAR_HAS_REALPATH)
+	add_compile_definitions(-DCLAR_HAS_REALPATH)
+endif()
 
 add_library(clar INTERFACE)
 target_sources(clar INTERFACE

--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -104,7 +104,7 @@ static int canonicalize_tmp_path(char *buffer)
 			*p = '/';
 
 	return 0;
-#elif defined(__APPLE__) || defined(HAS_REALPATH)
+#elif defined(CLAR_HAS_REALPATH)
 	char tmp[CLAR_MAX_PATH];
 
 	if (realpath(buffer, tmp) == NULL)


### PR DESCRIPTION
Given that test names can be long _and_ some platforms insist upon a
short maximum path length (eg, Windows), we may not want to
indiscriminately use path names as the sandbox directory name.

However, this has high utility in some situations, so allow it as an
opt-in. By default, we'll just use an 8 hexadigit "random" string.
(We'll use the rand(3) mechanism, which is not be particularly random,
but since the sandbox directories are sequestered in a unique tempdir,
a clar process need only attempt to avoid collisions between itself,
not with other processes.)