### PR TITLE
Multi line error message and NULL pointer fixes

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -787,7 +787,12 @@ void clar__assert_equal(
 				p_snprintf(buf, sizeof(buf), "'%s' != '%s' (at byte %d)",
 					s1, s2, pos);
 			} else {
-				p_snprintf(buf, sizeof(buf), "'%s' != '%s'", s1, s2);
+				const char *q1 = s1 ? "'" : "";
+				const char *q2 = s2 ? "'" : "";
+				s1 = s1 ? s1 : "NULL";
+				s2 = s2 ? s2 : "NULL";
+				p_snprintf(buf, sizeof(buf), "%s%s%s != %s%s%s",
+					   q1, s1, q1, q2, s2, q2);
 			}
 		}
 	}
@@ -805,7 +810,12 @@ void clar__assert_equal(
 				p_snprintf(buf, sizeof(buf), "'%.*s' != '%.*s' (at byte %d)",
 					len, s1, len, s2, pos);
 			} else {
-				p_snprintf(buf, sizeof(buf), "'%.*s' != '%.*s'", len, s1, len, s2);
+				const char *q1 = s1 ? "'" : "";
+				const char *q2 = s2 ? "'" : "";
+				s1 = s1 ? s1 : "NULL";
+				s2 = s2 ? s2 : "NULL";
+				p_snprintf(buf, sizeof(buf), "%s%.*s%s != %s%.*s%s",
+					   q1, len, s1, q1, q2, len, s2, q2);
 			}
 		}
 	}
@@ -823,7 +833,12 @@ void clar__assert_equal(
 				p_snprintf(buf, sizeof(buf), "'%ls' != '%ls' (at byte %d)",
 					wcs1, wcs2, pos);
 			} else {
-				p_snprintf(buf, sizeof(buf), "'%ls' != '%ls'", wcs1, wcs2);
+				const char *q1 = wcs1 ? "'" : "";
+				const char *q2 = wcs2 ? "'" : "";
+				wcs1 = wcs1 ? wcs1 : L"NULL";
+				wcs2 = wcs2 ? wcs2 : L"NULL";
+				p_snprintf(buf, sizeof(buf), "%s%ls%s != %s%ls%s",
+					   q1, wcs1, q1, q2, wcs2, q2);
 			}
 		}
 	}
@@ -841,7 +856,12 @@ void clar__assert_equal(
 				p_snprintf(buf, sizeof(buf), "'%.*ls' != '%.*ls' (at byte %d)",
 					len, wcs1, len, wcs2, pos);
 			} else {
-				p_snprintf(buf, sizeof(buf), "'%.*ls' != '%.*ls'", len, wcs1, len, wcs2);
+				const char *q1 = wcs1 ? "'" : "";
+				const char *q2 = wcs2 ? "'" : "";
+				wcs1 = wcs1 ? wcs1 : L"NULL";
+				wcs2 = wcs2 ? wcs2 : L"NULL";
+				p_snprintf(buf, sizeof(buf), "%s%.*ls%s != %s%.*ls%s",
+					   q1, len, wcs1, q1, q2, len, wcs2, q2);
 			}
 		}
 	}

--- a/clar/print.h
+++ b/clar/print.h
@@ -17,6 +17,22 @@ static void clar_print_clap_shutdown(int test_count, int suite_count, int error_
 	clar_report_all();
 }
 
+
+static void clar_print_indented(const char *str, int indent)
+{
+	const char *bol, *eol;
+
+	for (bol = str; *bol; bol = eol) {
+		eol = strchr(bol, '\n');
+		if (eol)
+			eol++;
+		else
+			eol = bol + strlen(bol);
+		printf("%*s%.*s", indent, "", (int)(eol - bol), bol);
+	}
+	putc('\n', stdout);
+}
+
 static void clar_print_clap_error(int num, const struct clar_report *report, const struct clar_error *error)
 {
 	printf("  %d) Failure:\n", num);
@@ -27,10 +43,10 @@ static void clar_print_clap_error(int num, const struct clar_report *report, con
 		error->file,
 		error->line_number);
 
-	printf("  %s\n", error->error_msg);
+	clar_print_indented(error->error_msg, 2);
 
 	if (error->description != NULL)
-		printf("  %s\n", error->description);
+		clar_print_indented(error->description, 2);
 
 	printf("\n");
 	fflush(stdout);
@@ -129,10 +145,10 @@ static void clar_print_tap_ontest(const char *suite_name, const char *test_name,
 
 		printf("    ---\n");
 		printf("    reason: |\n");
-		printf("      %s\n", error->error_msg);
+		clar_print_indented(error->error_msg, 6);
 
 		if (error->description)
-			printf("      %s\n", error->description);
+			clar_print_indented(error->description, 6);
 
 		printf("    at:\n");
 		printf("      file: '"); print_escaped(error->file); printf("'\n");

--- a/test/expected/quiet
+++ b/test/expected/quiet
@@ -38,6 +38,12 @@ selftest::suite::ptr [file:42]
   Pointer mismatch: p1 != p2
   0x1 != 0x2
 
+  1) Failure:
+selftest::suite::multiline_description [file:42]
+  Function call failed: -1
+  description line 1
+  description line 2
+
 
 
   1) Failure:
@@ -77,4 +83,10 @@ selftest::suite::bool [file:42]
 selftest::suite::ptr [file:42]
   Pointer mismatch: p1 != p2
   0x1 != 0x2
+
+  9) Failure:
+selftest::suite::multiline_description [file:42]
+  Function call failed: -1
+  description line 1
+  description line 2
 

--- a/test/expected/quiet
+++ b/test/expected/quiet
@@ -44,6 +44,11 @@ selftest::suite::multiline_description [file:42]
   description line 1
   description line 2
 
+  1) Failure:
+selftest::suite::null_string [file:42]
+  String mismatch: "expected" != actual ("this one fails")
+  'expected' != NULL
+
 
 
   1) Failure:
@@ -89,4 +94,9 @@ selftest::suite::multiline_description [file:42]
   Function call failed: -1
   description line 1
   description line 2
+
+  10) Failure:
+selftest::suite::null_string [file:42]
+  String mismatch: "expected" != actual ("this one fails")
+  'expected' != NULL
 

--- a/test/expected/summary.xml
+++ b/test/expected/summary.xml
@@ -32,5 +32,10 @@
 			<failure type="assert"><![CDATA[Pointer mismatch: p1 != p2
 0x1 != 0x2]]></failure>
 		</testcase>
+		<testcase name="multiline_description" classname="selftest" time="0.00">
+			<failure type="assert"><![CDATA[Function call failed: −1
+description line 1
+description line 2]]></failure>
+		</testcase>
 	</testsuite>
 </testsuites>

--- a/test/expected/summary.xml
+++ b/test/expected/summary.xml
@@ -37,5 +37,9 @@
 description line 1
 description line 2]]></failure>
 		</testcase>
+		<testcase name="null_string" classname="selftest" time="0.00">
+			<failure type="assert"><![CDATA[String mismatch: "expected" != actual ("this one fails")
+'expected' != NULL]]></failure>
+		</testcase>
 	</testsuite>
 </testsuites>

--- a/test/expected/summary_with_filename
+++ b/test/expected/summary_with_filename
@@ -1,6 +1,6 @@
 Loaded 1 suites: 
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
-FFFFFFFF
+FFFFFFFFF
 
   1) Failure:
 selftest::suite::1 [file:42]
@@ -39,5 +39,11 @@ selftest::suite::bool [file:42]
 selftest::suite::ptr [file:42]
   Pointer mismatch: p1 != p2
   0x1 != 0x2
+
+  9) Failure:
+selftest::suite::multiline_description [file:42]
+  Function call failed: -1
+  description line 1
+  description line 2
 
 written summary file to different.xml

--- a/test/expected/summary_with_filename
+++ b/test/expected/summary_with_filename
@@ -1,6 +1,6 @@
 Loaded 1 suites: 
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
-FFFFFFFFF
+FFFFFFFFFF
 
   1) Failure:
 selftest::suite::1 [file:42]
@@ -45,5 +45,10 @@ selftest::suite::multiline_description [file:42]
   Function call failed: -1
   description line 1
   description line 2
+
+  10) Failure:
+selftest::suite::null_string [file:42]
+  String mismatch: "expected" != actual ("this one fails")
+  'expected' != NULL
 
 written summary file to different.xml

--- a/test/expected/summary_without_filename
+++ b/test/expected/summary_without_filename
@@ -1,6 +1,6 @@
 Loaded 1 suites: 
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
-FFFFFFFF
+FFFFFFFFF
 
   1) Failure:
 selftest::suite::1 [file:42]
@@ -39,5 +39,11 @@ selftest::suite::bool [file:42]
 selftest::suite::ptr [file:42]
   Pointer mismatch: p1 != p2
   0x1 != 0x2
+
+  9) Failure:
+selftest::suite::multiline_description [file:42]
+  Function call failed: -1
+  description line 1
+  description line 2
 
 written summary file to summary.xml

--- a/test/expected/summary_without_filename
+++ b/test/expected/summary_without_filename
@@ -1,6 +1,6 @@
 Loaded 1 suites: 
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
-FFFFFFFFF
+FFFFFFFFFF
 
   1) Failure:
 selftest::suite::1 [file:42]
@@ -45,5 +45,10 @@ selftest::suite::multiline_description [file:42]
   Function call failed: -1
   description line 1
   description line 2
+
+  10) Failure:
+selftest::suite::null_string [file:42]
+  String mismatch: "expected" != actual ("this one fails")
+  'expected' != NULL
 
 written summary file to summary.xml

--- a/test/expected/tap
+++ b/test/expected/tap
@@ -89,4 +89,14 @@ not ok 9 - selftest::suite::multiline_description
       line: 42
       function: 'func'
     ---
-1..9
+not ok 10 - selftest::suite::null_string
+    ---
+    reason: |
+      String mismatch: "expected" != actual ("this one fails")
+      'expected' != NULL
+    at:
+      file: 'file'
+      line: 42
+      function: 'func'
+    ---
+1..10

--- a/test/expected/tap
+++ b/test/expected/tap
@@ -78,4 +78,15 @@ not ok 8 - selftest::suite::ptr
       line: 42
       function: 'func'
     ---
-1..8
+not ok 9 - selftest::suite::multiline_description
+    ---
+    reason: |
+      Function call failed: -1
+      description line 1
+      description line 2
+    at:
+      file: 'file'
+      line: 42
+      function: 'func'
+    ---
+1..9

--- a/test/expected/without_arguments
+++ b/test/expected/without_arguments
@@ -1,6 +1,6 @@
 Loaded 1 suites: 
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
-FFFFFFFFF
+FFFFFFFFFF
 
   1) Failure:
 selftest::suite::1 [file:42]
@@ -45,4 +45,9 @@ selftest::suite::multiline_description [file:42]
   Function call failed: -1
   description line 1
   description line 2
+
+  10) Failure:
+selftest::suite::null_string [file:42]
+  String mismatch: "expected" != actual ("this one fails")
+  'expected' != NULL
 

--- a/test/expected/without_arguments
+++ b/test/expected/without_arguments
@@ -1,6 +1,6 @@
 Loaded 1 suites: 
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
-FFFFFFFF
+FFFFFFFFF
 
   1) Failure:
 selftest::suite::1 [file:42]
@@ -39,4 +39,10 @@ selftest::suite::bool [file:42]
 selftest::suite::ptr [file:42]
   Pointer mismatch: p1 != p2
   0x1 != 0x2
+
+  9) Failure:
+selftest::suite::multiline_description [file:42]
+  Function call failed: -1
+  description line 1
+  description line 2
 

--- a/test/selftest.c
+++ b/test/selftest.c
@@ -244,7 +244,7 @@ void test_selftest__help(void)
 
 void test_selftest__without_arguments(void)
 {
-	cl_invoke(run("without_arguments", 8, NULL));
+	cl_invoke(run("without_arguments", 9, NULL));
 }
 
 void test_selftest__specific_test(void)
@@ -259,12 +259,12 @@ void test_selftest__stop_on_failure(void)
 
 void test_selftest__quiet(void)
 {
-	cl_invoke(run("quiet", 8, "-q", NULL));
+	cl_invoke(run("quiet", 9, "-q", NULL));
 }
 
 void test_selftest__tap(void)
 {
-	cl_invoke(run("tap", 8, "-t", NULL));
+	cl_invoke(run("tap", 9, "-t", NULL));
 }
 
 void test_selftest__suite_names(void)
@@ -275,7 +275,7 @@ void test_selftest__suite_names(void)
 void test_selftest__summary_without_filename(void)
 {
 	struct stat st;
-	cl_invoke(run("summary_without_filename", 8, "-r", NULL));
+	cl_invoke(run("summary_without_filename", 9, "-r", NULL));
 	/* The summary contains timestamps, so we cannot verify its contents. */
 	cl_must_pass(stat("summary.xml", &st));
 }
@@ -283,7 +283,7 @@ void test_selftest__summary_without_filename(void)
 void test_selftest__summary_with_filename(void)
 {
 	struct stat st;
-	cl_invoke(run("summary_with_filename", 8, "-rdifferent.xml", NULL));
+	cl_invoke(run("summary_with_filename", 9, "-rdifferent.xml", NULL));
 	/* The summary contains timestamps, so we cannot verify its contents. */
 	cl_must_pass(stat("different.xml", &st));
 }

--- a/test/selftest.c
+++ b/test/selftest.c
@@ -244,7 +244,7 @@ void test_selftest__help(void)
 
 void test_selftest__without_arguments(void)
 {
-	cl_invoke(run("without_arguments", 9, NULL));
+	cl_invoke(run("without_arguments", 10, NULL));
 }
 
 void test_selftest__specific_test(void)
@@ -259,12 +259,12 @@ void test_selftest__stop_on_failure(void)
 
 void test_selftest__quiet(void)
 {
-	cl_invoke(run("quiet", 9, "-q", NULL));
+	cl_invoke(run("quiet", 10, "-q", NULL));
 }
 
 void test_selftest__tap(void)
 {
-	cl_invoke(run("tap", 9, "-t", NULL));
+	cl_invoke(run("tap", 10, "-t", NULL));
 }
 
 void test_selftest__suite_names(void)
@@ -275,7 +275,7 @@ void test_selftest__suite_names(void)
 void test_selftest__summary_without_filename(void)
 {
 	struct stat st;
-	cl_invoke(run("summary_without_filename", 9, "-r", NULL));
+	cl_invoke(run("summary_without_filename", 10, "-r", NULL));
 	/* The summary contains timestamps, so we cannot verify its contents. */
 	cl_must_pass(stat("summary.xml", &st));
 }
@@ -283,7 +283,7 @@ void test_selftest__summary_without_filename(void)
 void test_selftest__summary_with_filename(void)
 {
 	struct stat st;
-	cl_invoke(run("summary_with_filename", 9, "-rdifferent.xml", NULL));
+	cl_invoke(run("summary_with_filename", 10, "-rdifferent.xml", NULL));
 	/* The summary contains timestamps, so we cannot verify its contents. */
 	cl_must_pass(stat("different.xml", &st));
 }

--- a/test/selftest_suite/selftest_suite.c
+++ b/test/selftest_suite/selftest_suite.c
@@ -83,3 +83,10 @@ void test_selftest_suite__multiline_description(void)
 {
 	cl_must_pass_(-1, "description line 1\ndescription line 2");
 }
+
+void test_selftest_suite__null_string(void)
+{
+	const char *actual = NULL;
+	cl_assert_equal_s(actual, actual);
+	cl_assert_equal_s_("expected", actual, "this one fails");
+}

--- a/test/selftest_suite/selftest_suite.c
+++ b/test/selftest_suite/selftest_suite.c
@@ -78,3 +78,8 @@ void test_selftest_suite__ptr(void)
 	cl_assert_equal_p(p1, p1); /* pointers to same object */
 	cl_assert_equal_p(p1, p2);
 }
+
+void test_selftest_suite__multiline_description(void)
+{
+	cl_must_pass_(-1, "description line 1\ndescription line 2");
+}


### PR DESCRIPTION
Indent all the lines in error messages and descriptions to ensure that the YAML embedded in TAP output is valid and fix an issue with passing NULL pointers to snprintf(). I've bundled these together as I couldn't figure out how to update the tests in two separate PR's without creating conflicts when they are both merged.