### PR TITLE
Fix formatting in quiet mode

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -150,7 +150,6 @@ static struct {
 
 	enum cl_output_format output_format;
 
-	int report_errors_only;
 	int exit_on_error;
 	int verbosity;
 
@@ -351,7 +350,7 @@ clar_run_test(
 	_clar.local_cleanup = NULL;
 	_clar.local_cleanup_payload = NULL;
 
-	if (_clar.report_errors_only) {
+	if (_clar.verbosity < 0) {
 		clar_report_errors(_clar.last_report);
 	} else {
 		clar_print_ontest(suite->name, test->name, _clar.tests_ran, _clar.last_report->status);
@@ -372,7 +371,7 @@ clar_run_suite(const struct clar_suite *suite, const char *filter)
 	if (_clar.exit_on_error && _clar.total_errors)
 		return;
 
-	if (!_clar.report_errors_only)
+	if (_clar.verbosity >= 0)
 		clar_print_onsuite(suite->name, ++_clar.suites_ran);
 
 	_clar.active_suite = suite->name;
@@ -440,7 +439,7 @@ clar_usage(const char *arg)
 	printf("  -iname        Include the suite with `name`\n");
 	printf("  -xname        Exclude the suite with `name`\n");
 	printf("  -v            Increase verbosity (show suite names)\n");
-	printf("  -q            Only report tests that had an error\n");
+	printf("  -q            Decrease verbosity, inverse to -v\n");
 	printf("  -Q            Quit as soon as a test fails\n");
 	printf("  -t            Display results in tap format\n");
 	printf("  -l            Print suite names\n");
@@ -532,7 +531,7 @@ clar_parse_args(int argc, char **argv)
 			if (argument[2] != '\0')
 				clar_usage(argv[0]);
 
-			_clar.report_errors_only = 1;
+			_clar.verbosity--;
 			break;
 
 		case 'Q':

--- a/clar.c
+++ b/clar.c
@@ -350,8 +350,7 @@ clar_run_test(
 	_clar.local_cleanup = NULL;
 	_clar.local_cleanup_payload = NULL;
 
-	if (_clar.verbosity >= 0)
-		clar_print_ontest(suite->name, test->name, _clar.tests_ran, _clar.last_report->status);
+	clar_print_ontest(suite->name, test->name, _clar.tests_ran, _clar.last_report->status);
 }
 
 static void
@@ -368,8 +367,7 @@ clar_run_suite(const struct clar_suite *suite, const char *filter)
 	if (_clar.exit_on_error && _clar.total_errors)
 		return;
 
-	if (_clar.verbosity >= 0)
-		clar_print_onsuite(suite->name, ++_clar.suites_ran);
+	clar_print_onsuite(suite->name, ++_clar.suites_ran);
 
 	_clar.active_suite = suite->name;
 	_clar.active_test = NULL;

--- a/clar.c
+++ b/clar.c
@@ -350,11 +350,8 @@ clar_run_test(
 	_clar.local_cleanup = NULL;
 	_clar.local_cleanup_payload = NULL;
 
-	if (_clar.verbosity < 0) {
-		clar_report_errors(_clar.last_report);
-	} else {
+	if (_clar.verbosity >= 0)
 		clar_print_ontest(suite->name, test->name, _clar.tests_ran, _clar.last_report->status);
-	}
 }
 
 static void

--- a/clar/print.h
+++ b/clar/print.h
@@ -57,6 +57,9 @@ static void clar_print_clap_ontest(const char *suite_name, const char *test_name
 	(void)test_name;
 	(void)test_number;
 
+	if (_clar.verbosity < 0)
+		return;
+
 	if (_clar.verbosity > 1) {
 		printf("%s::%s: ", suite_name, test_name);
 
@@ -80,6 +83,8 @@ static void clar_print_clap_ontest(const char *suite_name, const char *test_name
 
 static void clar_print_clap_onsuite(const char *suite_name, int suite_index)
 {
+	if (_clar.verbosity < 0)
+		return;
 	if (_clar.verbosity == 1)
 		printf("\n%s", suite_name);
 
@@ -133,6 +138,9 @@ static void clar_print_tap_ontest(const char *suite_name, const char *test_name,
 {
 	const struct clar_error *error = _clar.last_report->errors;
 
+	if (_clar.verbosity < 0)
+		return;
+
 	(void)test_name;
 	(void)test_number;
 
@@ -168,6 +176,8 @@ static void clar_print_tap_ontest(const char *suite_name, const char *test_name,
 
 static void clar_print_tap_onsuite(const char *suite_name, int suite_index)
 {
+	if (_clar.verbosity < 0)
+		return;
 	printf("# start of suite %d: %s\n", suite_index, suite_name);
 }
 

--- a/clar/print.h
+++ b/clar/print.h
@@ -3,6 +3,10 @@
 static void clar_print_clap_init(int test_count, int suite_count, const char *suite_names)
 {
 	(void)test_count;
+
+	if (_clar.verbosity < 0)
+		return;
+
 	printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
 	printf("Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')\n");
 }
@@ -13,7 +17,8 @@ static void clar_print_clap_shutdown(int test_count, int suite_count, int error_
 	(void)suite_count;
 	(void)error_count;
 
-	printf("\n\n");
+	if (_clar.verbosity >= 0)
+		printf("\n\n");
 	clar_report_all();
 }
 

--- a/clar/print.h
+++ b/clar/print.h
@@ -138,9 +138,6 @@ static void clar_print_tap_ontest(const char *suite_name, const char *test_name,
 {
 	const struct clar_error *error = _clar.last_report->errors;
 
-	if (_clar.verbosity < 0)
-		return;
-
 	(void)test_name;
 	(void)test_number;
 
@@ -151,18 +148,20 @@ static void clar_print_tap_ontest(const char *suite_name, const char *test_name,
 	case CL_TEST_FAILURE:
 		printf("not ok %d - %s::%s\n", test_number, suite_name, test_name);
 
-		printf("    ---\n");
-		printf("    reason: |\n");
-		clar_print_indented(error->error_msg, 6);
+		if (_clar.verbosity >= 0) {
+			printf("    ---\n");
+			printf("    reason: |\n");
+			clar_print_indented(error->error_msg, 6);
 
-		if (error->description)
-			clar_print_indented(error->description, 6);
+			if (error->description)
+				clar_print_indented(error->description, 6);
 
-		printf("    at:\n");
-		printf("      file: '"); print_escaped(error->file); printf("'\n");
-		printf("      line: %" PRIuMAX "\n", error->line_number);
-		printf("      function: '%s'\n", error->function);
-		printf("    ---\n");
+			printf("    at:\n");
+			printf("      file: '"); print_escaped(error->file); printf("'\n");
+			printf("      line: %" PRIuMAX "\n", error->line_number);
+			printf("      function: '%s'\n", error->function);
+			printf("    ---\n");
+		}
 
 		break;
 	case CL_TEST_SKIP:

--- a/test/expected/help
+++ b/test/expected/help
@@ -5,7 +5,7 @@ Options:
   -iname        Include the suite with `name`
   -xname        Exclude the suite with `name`
   -v            Increase verbosity (show suite names)
-  -q            Only report tests that had an error
+  -q            Decrease verbosity, inverse to -v
   -Q            Quit as soon as a test fails
   -t            Display results in tap format
   -l            Print suite names

--- a/test/expected/quiet
+++ b/test/expected/quiet
@@ -1,7 +1,3 @@
-Loaded 1 suites: 
-Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
-
-
   1) Failure:
 selftest::suite::1 [file:42]
   Function call failed: -1

--- a/test/expected/quiet
+++ b/test/expected/quiet
@@ -1,54 +1,5 @@
 Loaded 1 suites: 
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
-  1) Failure:
-selftest::suite::1 [file:42]
-  Function call failed: -1
-
-  1) Failure:
-selftest::suite::2 [file:42]
-  Expression is not true: 100 == 101
-
-  1) Failure:
-selftest::suite::strings [file:42]
-  String mismatch: "mismatched" != actual ("this one fails")
-  'mismatched' != 'expected' (at byte 0)
-
-  1) Failure:
-selftest::suite::strings_with_length [file:42]
-  String mismatch: "exactly" != actual ("this one fails")
-  'exa' != 'exp' (at byte 2)
-
-  1) Failure:
-selftest::suite::int [file:42]
-  101 != value ("extra note on failing test")
-  101 != 100
-
-  1) Failure:
-selftest::suite::int_fmt [file:42]
-  022 != value
-  0022 != 0144
-
-  1) Failure:
-selftest::suite::bool [file:42]
-  0 != value
-  0 != 1
-
-  1) Failure:
-selftest::suite::ptr [file:42]
-  Pointer mismatch: p1 != p2
-  0x1 != 0x2
-
-  1) Failure:
-selftest::suite::multiline_description [file:42]
-  Function call failed: -1
-  description line 1
-  description line 2
-
-  1) Failure:
-selftest::suite::null_string [file:42]
-  String mismatch: "expected" != actual ("this one fails")
-  'expected' != NULL
-
 
 
   1) Failure:


### PR DESCRIPTION
The quiet mode activated via "-q" is quite broken:

- We print all failures twice with clap formatting, so we effectively increase verbosity.
- We don't print individual test status indicators ("...FF..F"), but print the legend to explain what the symbols mean.
- We don't print any "ok/not ok" lines at all with TAP formatting, which breaks the specification.

This PR fixes all of those issues.