### PR TITLE
clar.c: fix -Wmaybe-uninitialized with -Og

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -359,7 +359,7 @@ static void
 clar_run_suite(const struct clar_suite *suite, const char *filter)
 {
 	const struct clar_func *test = suite->tests;
-	size_t i, matchlen;
+	size_t i, matchlen = 0;
 	struct clar_report *report;
 	int exact = 0;
 


### PR DESCRIPTION
When building with -Og and -Wmaybe-uninitialized on gcc 15.1.1, the build produces a warning. In practice, though, this cannot be hit because `exact` acts as a guard and that variable can only be set after `matchlen` is already initialized

Assign a default value to `matchlen` so that the warning is silenced.

This patch is taken from [0].

[0]: https://github.com/git/git/commit/3a7e783d9c5334cc5ea1af74b42297560ce697ce