### PR TITLE
clar/sandbox: fix compatibility with HP-UX

### DIFF
--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -164,7 +164,7 @@ static int build_tempdir_path(void)
 
 	if (mkdir(_clar_tempdir, 0700) != 0)
 		return -1;
-#elif defined(__sun) || defined(__TANDEM)
+#elif defined(__sun) || defined(__TANDEM) || defined(__hpux)
 	if (mktemp(_clar_tempdir) == NULL)
 		return -1;
 


### PR DESCRIPTION
It was reported on the Git mailing list [1] that compiling clar on HP-UX fails because that platform does not have mkdtemp(3) available. Fix this by using mktemp(3) instead by adding another check for the `__hpux` preprocessor define.

[1]: https://lore.kernel.org/git/d8d4266e-838c-488e-9aaf-4a1be0169795@innomotics.com/