### PR TITLE
fs: fix -Wcomma warnings in `fs_rmdir_helper()`

### DIFF
--- a/clar/fs.h
+++ b/clar/fs.h
@@ -470,11 +470,17 @@ static void
 fs_rmdir_helper(const char *path)
 {
 	DIR *dir;
-	struct dirent *d;
 
 	cl_assert_(dir = opendir(path), "Could not open dir");
-	while ((d = (errno = 0, readdir(dir))) != NULL) {
+
+	while (1) {
+		struct dirent *d;
 		char *child;
+
+		errno = 0;
+		d = readdir(dir);
+		if (!d)
+			break;
 
 		if (!strcmp(d->d_name, ".") || !strcmp(d->d_name, ".."))
 			continue;


### PR DESCRIPTION
There's a new warning in "fs.h" due to possible misuse of the comma operator:

    ::error file=t/unit-tests/clar/clar/fs.h,line=373::t/unit-tests/clar/clar/fs.h:373:24: possible misuse of comma operator here [-Werror,-Wcomma]
      373 |         while ((d = (errno = 0, readdir(source_dir))) != NULL) {
          |                               ^

Fix the issue by checking for the result of readdir(3p) inside of the loop.