### PR TITLE
fs: fix -Wcomma warnings in `fs_copydir_helper()`

### DIFF
--- a/clar/fs.h
+++ b/clar/fs.h
@@ -365,13 +365,18 @@ static void
 fs_copydir_helper(const char *source, const char *dest, int dest_mode)
 {
 	DIR *source_dir;
-	struct dirent *d;
 
 	mkdir(dest, dest_mode);
 
 	cl_assert_(source_dir = opendir(source), "Could not open source dir");
-	while ((d = (errno = 0, readdir(source_dir))) != NULL) {
+	while (1) {
+		struct dirent *d;
 		char *child;
+
+		errno = 0;
+		d = readdir(source_dir);
+		if (!d)
+			break;
 
 		if (!strcmp(d->d_name, ".") || !strcmp(d->d_name, ".."))
 			continue;


### PR DESCRIPTION
Same as in 3b04153 (fs: fix -Wcomma warnings in `fs_rmdir_helper()`, 2025-09-09), we have another warning with the same root cause in `fs_copydir_helper()`. Fix the issue by checking for the result of readdir(3p) inside of the loop.