### PR TITLE
clar/sandbox: fix ubsan due to shifting signed integer

### DIFF
--- a/clar/sandbox.h
+++ b/clar/sandbox.h
@@ -191,7 +191,7 @@ static void clar_tempdir_init(void)
 #if !defined(CLAR_SANDBOX_TEST_NAMES) && defined(_WIN32)
 	srand(clock() ^ (unsigned int)time(NULL) ^ GetCurrentProcessId() ^ GetCurrentThreadId());
 #elif !defined(CLAR_SANDBOX_TEST_NAMES)
-	srand(clock() ^ time(NULL) ^ (getpid() << 16));
+	srand(clock() ^ time(NULL) ^ ((unsigned)getpid() << 16));
 #endif
 }
 


### PR DESCRIPTION
When compiling clar with the undefined behaviour sanitizer we can observe the following error:

    ../t/unit-tests/clar/clar/sandbox.h:194:41: runtime error: left shift of 2513427 by 16 places cannot be represented in type '__pid_t' (aka 'int')
        #0 0x555555d5c5bb in clar_tempdir_init /home/pks/Development/git/build/../t/unit-tests/clar/clar/sandbox.h:194:41
        #1 0x555555d59d0d in clar_test_init /home/pks/Development/git/build/../t/unit-tests/clar/clar.c:615:2
        #2 0x555555d5f532 in clar_test /home/pks/Development/git/build/../t/unit-tests/clar/clar.c:679:2
        #3 0x555555d6ad78 in cmd_main /home/pks/Development/git/build/../t/unit-tests/unit-test.c:61:8
        #4 0x555555dd27f2 in main /home/pks/Development/git/build/../common-main.c:9:11
        #5 0x7ffff7a2a4d7 in __libc_start_call_main (/nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/libc.so.6+0x2a4d7) (BuildId: 5aac2941d06983de887fda949fc2ad3d17051eaf)
        #6 0x7ffff7a2a59a in __libc_start_main@GLIBC_2.2.5 (/nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/libc.so.6+0x2a59a) (BuildId: 5aac2941d06983de887fda949fc2ad3d17051eaf)
        #7 0x555555c19b04 in _start (/home/pks/Development/git/build/t/unit-tests+0x6c5b04)

This error is raised by the following code:

    srand(clock() ^ time(NULL) ^ (getpid() << 16));

Fix this undefined behaviour by explicitly casting the PID to an unsigned integer.