### PR TITLE
clar/print: drop unused suite names

### DIFF
--- a/clar.c
+++ b/clar.c
@@ -195,7 +195,7 @@ struct clar_suite {
 };
 
 /* From clar_print_*.c */
-static void clar_print_init(int test_count, int suite_count, const char *suite_names);
+static void clar_print_init(int test_count, int suite_count);
 static void clar_print_shutdown(int test_count, int suite_count, int error_count);
 static void clar_print_error(int num, const struct clar_report *report, const struct clar_error *error);
 static void clar_print_ontest(const char *suite_name, const char *test_name, int test_number, enum cl_test_status failed);
@@ -592,11 +592,7 @@ clar_test_init(int argc, char **argv)
 	if (argc > 1)
 		clar_parse_args(argc, argv);
 
-	clar_print_init(
-		(int)_clar_callback_count,
-		(int)_clar_suite_count,
-		""
-	);
+	clar_print_init((int)_clar_callback_count, (int)_clar_suite_count);
 
 	if (!_clar.summary_filename &&
 	    (summary_env = getenv("CLAR_SUMMARY")) != NULL) {

--- a/clar/print.h
+++ b/clar/print.h
@@ -1,13 +1,13 @@
 /* clap: clar protocol, the traditional clar output format */
 
-static void clar_print_clap_init(int test_count, int suite_count, const char *suite_names)
+static void clar_print_clap_init(int test_count, int suite_count)
 {
 	(void)test_count;
 
 	if (_clar.verbosity < 0)
 		return;
 
-	printf("Loaded %d suites: %s\n", (int)suite_count, suite_names);
+	printf("Loaded %d suites:\n", (int)suite_count);
 	printf("Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')\n");
 }
 
@@ -103,11 +103,10 @@ static void clar_print_clap_onabort(const char *fmt, va_list arg)
 
 /* tap: test anywhere protocol format */
 
-static void clar_print_tap_init(int test_count, int suite_count, const char *suite_names)
+static void clar_print_tap_init(int test_count, int suite_count)
 {
 	(void)test_count;
 	(void)suite_count;
-	(void)suite_names;
 	printf("TAP version 13\n");
 }
 
@@ -207,9 +206,9 @@ static void clar_print_tap_onabort(const char *fmt, va_list arg)
 		} \
 	} while (0)
 
-static void clar_print_init(int test_count, int suite_count, const char *suite_names)
+static void clar_print_init(int test_count, int suite_count)
 {
-	PRINT(init, test_count, suite_count, suite_names);
+	PRINT(init, test_count, suite_count);
 }
 
 static void clar_print_shutdown(int test_count, int suite_count, int error_count)

--- a/test/expected/specific_test
+++ b/test/expected/specific_test
@@ -1,4 +1,4 @@
-Loaded 1 suites: 
+Loaded 1 suites:
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
 F
 

--- a/test/expected/stop_on_failure
+++ b/test/expected/stop_on_failure
@@ -1,4 +1,4 @@
-Loaded 1 suites: 
+Loaded 1 suites:
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
 F
 

--- a/test/expected/summary_with_filename
+++ b/test/expected/summary_with_filename
@@ -1,4 +1,4 @@
-Loaded 1 suites: 
+Loaded 1 suites:
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
 FFFFFFFFFF
 

--- a/test/expected/summary_without_filename
+++ b/test/expected/summary_without_filename
@@ -1,4 +1,4 @@
-Loaded 1 suites: 
+Loaded 1 suites:
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
 FFFFFFFFFF
 

--- a/test/expected/without_arguments
+++ b/test/expected/without_arguments
@@ -1,4 +1,4 @@
-Loaded 1 suites: 
+Loaded 1 suites:
 Started (test status codes: OK='.' FAILURE='F' SKIPPED='S')
 FFFFFFFFFF
 


### PR DESCRIPTION
When printing the initial status we pass the number of tests, the number of suites and the suite names to `clar_print_init()`. But while the former two pieces of information do get used when using the Clap format, we only ever pass an empty string as suite name.

Besides being unnecessary, it also has the consequence that we print an empty space, as the final "%s" in "Loaded %d suites: %s\n" is always going to be the empty string.

Remove the unused parameter and drop the trailing space. Adapt our tests accordingly.