### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       if: matrix.platform.image == 'i386/debian:latest'
       run: apt -q update && apt -q -y install cmake gcc libc6-amd64 lib64stdc++6 make python3
     - name: Check out
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Build
       shell: bash
       run: |


### PR DESCRIPTION
- Between when I made https://github.com/clar-test/clar/pull/128 and when it was merged, github released v6 https://github.com/actions/checkout/releases/tag/v6.0.0 (they're now on v6.0.1)...

I'm sorry, normally they don't run through versions anywhere near this often...