### PR TITLE
clar: define CLAR_MAX_PATH even w/o PATH_MAX

### DIFF
--- a/clar.h
+++ b/clar.h
@@ -15,8 +15,10 @@
 # define CLAR_MAX_PATH 4096
 #elif defined(_WIN32)
 # define CLAR_MAX_PATH MAX_PATH
-#else
+#elif defined(PATH_MAX)
 # define CLAR_MAX_PATH PATH_MAX
+#else
+# define CLAR_MAX_PATH 4096
 #endif
 
 #ifndef CLAR_SELFTEST


### PR DESCRIPTION
`PATH_MAX` is an optional constant in POSIX, and at least on GNU/Hurd it is not provided on purpose.

Define `CLAR_MAX_PATH` to a static value in case `PATH_MAX` is not available, using the same value used for the "Windows with long paths" case. In the end, 4096 should not be a problem for a test framework.