### PR TITLE
reporting: const correctness

### DIFF
--- a/clar/print.h
+++ b/clar/print.h
@@ -127,7 +127,7 @@ static void clar_print_tap_error(int num, const struct clar_report *report, cons
 
 static void print_escaped(const char *str)
 {
-	char *c;
+	const char *c;
 
 	while ((c = strchr(str, '\'')) != NULL) {
 		printf("%.*s", (int)(c - str), str);


### PR DESCRIPTION
The string to escape is `const char *`. So should be the iterator pointer.