### PR TITLE
Add github URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,9 +324,10 @@ About Clar
 
 Clar was originally written by [Vicent Martí](https://github.com/vmg),
 to replace the old testing framework in [libgit2][libgit2]. It is
-currently maintained by [Edward Thomson](https://github.com/ethomson),
-and used by the [libgit2][libgit2] and [git][git] projects, amongst
-others.
+currently maintained on [GitHub][github] by
+[Edward Thomson](https://github.com/ethomson), and used by the
+[libgit2][libgit2] and [git][git] projects, amongst others.
 
+[github]: https://github.com/clar-test/clar
 [libgit2]: https://github.com/libgit2/libgit2
 [git]: https://github.com/git/git


### PR DESCRIPTION
So that imports into other projects (e.g. git) link to the upstream repository.